### PR TITLE
feat: added ability to swap token on and from ZetaChain

### DIFF
--- a/omnichain/swap/contracts/Swap.sol
+++ b/omnichain/swap/contracts/Swap.sol
@@ -42,15 +42,24 @@ contract Swap is zContract, OnlySystem {
             params.to = recipient;
         }
 
+        swapAndWithdraw(zrc20, amount, params.target, params.to);
+    }
+
+    function swapAndWithdraw(
+        address inputToken,
+        uint256 amount,
+        address targetToken,
+        bytes memory recipient
+    ) internal {
         uint256 inputForGas;
         address gasZRC20;
         uint256 gasFee;
 
-        (gasZRC20, gasFee) = IZRC20(params.target).withdrawGasFee();
+        (gasZRC20, gasFee) = IZRC20(targetToken).withdrawGasFee();
 
         inputForGas = SwapHelperLib.swapTokensForExactTokens(
             systemContract,
-            zrc20,
+            inputToken,
             gasFee,
             gasZRC20,
             amount
@@ -58,13 +67,13 @@ contract Swap is zContract, OnlySystem {
 
         uint256 outputAmount = SwapHelperLib.swapExactTokensForTokens(
             systemContract,
-            zrc20,
+            inputToken,
             amount - inputForGas,
-            params.target,
+            targetToken,
             0
         );
 
-        IZRC20(gasZRC20).approve(params.target, gasFee);
-        IZRC20(params.target).withdraw(params.to, outputAmount);
+        IZRC20(gasZRC20).approve(targetToken, gasFee);
+        IZRC20(targetToken).withdraw(recipient, outputAmount);
     }
 }

--- a/omnichain/swap/contracts/SwapToAnyToken.sol
+++ b/omnichain/swap/contracts/SwapToAnyToken.sol
@@ -9,6 +9,7 @@ import "@zetachain/protocol-contracts/contracts/zevm/interfaces/IWZETA.sol";
 import "@zetachain/toolkit/contracts/OnlySystem.sol";
 
 contract SwapToAnyToken is zContract, OnlySystem {
+    error TransferFailed();
     SystemContract public systemContract;
 
     uint256 constant BITCOIN = 18332;
@@ -121,8 +122,12 @@ contract SwapToAnyToken is zContract, OnlySystem {
         bytes memory recipient,
         bool withdraw
     ) public {
-        IZRC20(inputToken).transferFrom(msg.sender, address(this), amount);
-
+        bool success = IZRC20(inputToken).transferFrom(
+            msg.sender,
+            address(this),
+            amount
+        );
+        if (!success) revert TransferFailed();
         swapAndWithdraw(inputToken, amount, targetToken, recipient, withdraw);
     }
 }

--- a/omnichain/swap/contracts/SwapToAnyToken.sol
+++ b/omnichain/swap/contracts/SwapToAnyToken.sol
@@ -72,7 +72,6 @@ contract SwapToAnyToken is zContract, OnlySystem {
         bytes memory recipient,
         bool withdraw
     ) internal {
-        uint256 outputAmount;
         uint256 inputForGas;
         address gasZRC20;
         uint256 gasFee;
@@ -89,7 +88,7 @@ contract SwapToAnyToken is zContract, OnlySystem {
             );
         }
 
-        outputAmount = SwapHelperLib.swapExactTokensForTokens(
+        uint256 outputAmount = SwapHelperLib.swapExactTokensForTokens(
             systemContract,
             inputToken,
             withdraw ? amount - inputForGas : amount,

--- a/omnichain/swap/contracts/SwapToAnyToken.sol
+++ b/omnichain/swap/contracts/SwapToAnyToken.sol
@@ -104,13 +104,15 @@ contract SwapToAnyToken is zContract, OnlySystem {
             address wzeta = systemContract.wZetaContractAddress();
             if (targetToken == wzeta) {
                 IWETH9(wzeta).withdraw(outputAmount);
-                address payable recipientAddress = payable(
+                address payable to = payable(
                     address(uint160(bytes20(recipient)))
                 );
-                recipientAddress.transfer(outputAmount);
+                (bool success, ) = to.call{value: outputAmount}("");
+                if (!success) revert TransferFailed();
             } else {
-                address recipientAddress = address(uint160(bytes20(recipient)));
-                IWETH9(targetToken).transfer(recipientAddress, outputAmount);
+                address to = address(uint160(bytes20(recipient)));
+                bool success = IWETH9(targetToken).transfer(to, outputAmount);
+                if (!success) revert TransferFailed();
             }
         }
     }

--- a/omnichain/swap/tasks/swap.ts
+++ b/omnichain/swap/tasks/swap.ts
@@ -1,0 +1,47 @@
+import { task } from "hardhat/config";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { parseEther } from "@ethersproject/units";
+import { ethers } from "ethers";
+
+const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
+  const [signer] = await hre.ethers.getSigners();
+
+  if (!/zeta_(testnet|mainnet)/.test(hre.network.name)) {
+    throw new Error('🚨 Please use either "zeta_testnet" or "zeta_mainnet".');
+  }
+
+  const factory = await hre.ethers.getContractFactory("SwapToAnyToken");
+  const contract = factory.attach(args.contract);
+
+  const amount = parseEther(args.amount);
+  const inputToken = args.inputToken;
+  const targetToken = args.targetToken;
+  const recipient = ethers.utils.arrayify(args.recipient);
+  const withdraw = JSON.parse(args.withdraw);
+
+  const erc20Factory = await hre.ethers.getContractFactory("ERC20");
+  const inputTokenContract = erc20Factory.attach(args.inputToken);
+
+  const approval = await inputTokenContract.approve(args.contract, amount);
+  await approval.wait();
+
+  const tx = await contract.swap(
+    inputToken,
+    amount,
+    targetToken,
+    recipient,
+    withdraw
+  );
+
+  await tx.wait();
+  console.log(`Transaction hash: ${tx.hash}`);
+};
+
+task("swap", "Interact with the Swap contract from ZetaChain", main)
+  .addFlag("json", "Output JSON")
+  .addParam("contract", "Contract address")
+  .addParam("amount", "Token amount to send")
+  .addParam("inputToken", "Input token address")
+  .addParam("targetToken", "Target token address")
+  .addParam("recipient", "Recipient address")
+  .addParam("withdraw", "Withdraw flag (true/false)");


### PR DESCRIPTION
Extracting the swap logic into a separate function makes it easy to add a set of additional swap features:

* swapping between tokens on ZetaChain (by making a call to the contract on ZetaChain directly).
* swap a token on ZetaChain and withdraw to a connected chain. Let's say you have ZRC-20 ETH already on ZetaChain and you want to withdraw BNB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new functions to facilitate token swapping operations and external payable transactions.
  - Added error handling for failed transfers.

- **Refactor**
  - Refactored internal logic for better code organization.

- **Improvements**
  - Enhanced token swap operations with new parameters for better flexibility and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->