### PR TITLE
ci: add slither integration

### DIFF
--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -1,0 +1,74 @@
+name: Slither
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+    types:
+      - synchronize
+      - opened
+      - reopened
+      - ready_for_review
+
+jobs:
+  slither:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - project: 'messaging/erc20'
+            file: 'm-erc20.sarif'
+          - project: 'messaging/message'
+            file: 'm-message.sarif'
+          - project: 'messaging/nft'
+            file: 'm-nft.sarif'
+          - project: 'messaging/zeta'
+            file: 'm-zeta.sarif'
+          - project: 'omnichain/multioutput'
+            file: 'o-multioutput.sarif'
+          - project: 'omnichain/nft'
+            file: 'o-nft.sarif'
+          - project: 'omnichain/staking'
+            file: 'o-staking.sarif'
+          - project: 'omnichain/swap'
+            file: 'o-swap.sarif'
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Build projects
+        continue-on-error: true
+        run: yarn build
+
+      - name: Run Slither on ${{ matrix.project}}
+        uses: crytic/slither-action@main
+        continue-on-error: true
+        with:
+          ignore-compile: true
+          sarif: ${{ matrix.file}}
+          node-version: '18'
+          target: ${{ matrix.project}}
+          fail-on: none
+
+      - name: Upload zevm-app-contracts SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ matrix.file}}

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,8 @@
+{
+	"detectors_to_exclude": "",
+	"compile_force_framework": "hardhat",
+	"hardhat_ignore_compile": true,
+	"npx_disable": true,
+	"foundry_ignore_compile": true,
+	"filter_paths": "artifacts,cache,data,dist,docs,lib,node_modules,pkg,scripts,tasks,test,testing,typechain-types"
+}


### PR DESCRIPTION
- Add Slither integration customized for this repository.
- Because the repository is multi-workspace we have to workaround using a matrix.
- Also, ignoring compiling from slither so we directly build using `yarn build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a GitHub Actions workflow to perform static analysis using Slither.
	- Introduced Slither configuration settings for improved code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->