### PR TITLE
Testing: read addresses from localnet.json

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,6 @@
 name: Run Tests
 
 on:
-  push:
   pull_request:
   workflow_dispatch:
 

--- a/examples/nft/package.json
+++ b/examples/nft/package.json
@@ -27,7 +27,7 @@
     "@types/node": ">=12.0.0",
     "@typescript-eslint/eslint-plugin": "^5.59.9",
     "@typescript-eslint/parser": "^5.59.9",
-    "@zetachain/localnet": "4.0.0-rc3",
+    "@zetachain/localnet": "4.0.0-rc4",
     "@zetachain/toolkit": "13.0.0-rc4",
     "axios": "^1.3.6",
     "chai": "^4.2.0",

--- a/examples/nft/scripts/test.sh
+++ b/examples/nft/scripts/test.sh
@@ -21,12 +21,11 @@ function nft_balance() {
 echo -e "\n🚀 Compiling contracts..."
 npx hardhat compile --force --quiet
 
-ZRC20_ETHEREUM=0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe # ZRC-20 of the gas token of Ethereum
-ZRC20_BNB=0x65a45c57636f9BcCeD4fe193A602008578BcA90b # ZRC-20 of the gas token of BNB
-GATEWAY_ETHEREUM=0x610178dA211FEF7D417bC0e6FeD39F05609AD788
-GATEWAY_BNB=0x3Aa5ebB10DC797CAC828524e59A333d0A371443c
+ZRC20_ETHEREUM=$(jq -r '.addresses[] | select(.type=="ZRC-20 ETH on 5") | .address' localnet.json)
+ZRC20_BNB=$(jq -r '.addresses[] | select(.type=="ZRC-20 BNB on 97") | .address' localnet.json)
+GATEWAY_ETHEREUM=$(jq -r '.addresses[] | select(.type=="gatewayEVM" and .chain=="ethereum") | .address' localnet.json)
+GATEWAY_BNB=$(jq -r '.addresses[] | select(.type=="gatewayEVM" and .chain=="bnb") | .address' localnet.json)
 SENDER=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-
 
 CONTRACT_ZETACHAIN=$(npx hardhat deploy --network localhost --json | jq -r '.contractAddress')
 echo -e "\n🚀 Deployed NFT contract on ZetaChain: $CONTRACT_ZETACHAIN"

--- a/examples/nft/yarn.lock
+++ b/examples/nft/yarn.lock
@@ -2743,10 +2743,10 @@
     typescript "5.5.4"
     zod "3.22.4"
 
-"@zetachain/localnet@4.0.0-rc3":
-  version "4.0.0-rc3"
-  resolved "https://registry.yarnpkg.com/@zetachain/localnet/-/localnet-4.0.0-rc3.tgz#72405fb23795aaa5eedd994b5078190e8330a20a"
-  integrity sha512-KPyz63H+eXK6V8mTmJNZ4KJfgEHu00BC3Bl+dn5BgzgD0Rh7R1pBYj+r0qGTm0FSBAFAv8ol3W46C1UK5t1iAA==
+"@zetachain/localnet@4.0.0-rc4":
+  version "4.0.0-rc4"
+  resolved "https://registry.yarnpkg.com/@zetachain/localnet/-/localnet-4.0.0-rc4.tgz#916c58f83dd4901691fbc1216aec2ee88e7f531e"
+  integrity sha512-yNlA6qaQZiuHXRx4pgNLLHlJ+2ENet9WTIWxoslnLzzDljWwYTJHkErlTQcWa5oL9jjyn2/hQB/laoqXzlX1gQ==
   dependencies:
     "@inquirer/prompts" "^5.5.0"
     "@uniswap/v2-core" "^1.0.1"


### PR DESCRIPTION
Replace hard coded protocol contract addresses with calls to `jq` reading addresses from `localnet.json`.

Also, run tests only on pull requests (to avoid having them run twice).