### PR TITLE
onlyGateway modifier

### DIFF
--- a/examples/hello/contracts/Echo.sol
+++ b/examples/hello/contracts/Echo.sol
@@ -10,6 +10,11 @@ contract Echo {
     event RevertEvent(string, RevertContext);
     event HelloEvent(string, string);
 
+    modifier onlyGateway() {
+        require(msg.sender == address(gateway), "Caller is not the gateway");
+        _;
+    }
+
     constructor(address payable gatewayAddress) {
         gateway = GatewayEVM(gatewayAddress);
     }
@@ -18,7 +23,9 @@ contract Echo {
         emit HelloEvent("Hello on EVM", message);
     }
 
-    function onRevert(RevertContext calldata revertContext) external {
+    function onRevert(
+        RevertContext calldata revertContext
+    ) external onlyGateway {
         emit RevertEvent("Revert on EVM", revertContext);
     }
 

--- a/examples/hello/contracts/Hello.sol
+++ b/examples/hello/contracts/Hello.sol
@@ -13,6 +13,11 @@ contract Hello is UniversalContract {
     event RevertEvent(string, RevertContext);
     error TransferFailed();
 
+    modifier onlyGateway() {
+        require(msg.sender == address(gateway), "Caller is not the gateway");
+        _;
+    }
+
     constructor(address payable gatewayAddress) {
         gateway = GatewayZEVM(gatewayAddress);
     }
@@ -22,12 +27,14 @@ contract Hello is UniversalContract {
         address zrc20,
         uint256 amount,
         bytes calldata message
-    ) external override {
+    ) external override onlyGateway {
         string memory name = abi.decode(message, (string));
         emit HelloEvent("Hello on ZetaChain", name);
     }
 
-    function onRevert(RevertContext calldata revertContext) external override {
+    function onRevert(
+        RevertContext calldata revertContext
+    ) external override onlyGateway {
         emit RevertEvent("Revert on ZetaChain", revertContext);
     }
 

--- a/examples/nft/contracts/Connected.sol
+++ b/examples/nft/contracts/Connected.sol
@@ -18,6 +18,11 @@ contract Connected is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
         counterparty = contractAddress;
     }
 
+    modifier onlyGateway() {
+        require(msg.sender == address(gateway), "Caller is not the gateway");
+        _;
+    }
+
     constructor(
         address payable gatewayAddress,
         address initialOwner
@@ -74,7 +79,7 @@ contract Connected is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
     function onCall(
         MessageContext calldata messageContext,
         bytes calldata message
-    ) external payable returns (bytes4) {
+    ) external payable onlyGateway returns (bytes4) {
         if (messageContext.sender != counterparty) revert("Unauthorized");
 
         (uint256 tokenId, address receiver, string memory uri) = abi.decode(
@@ -86,7 +91,7 @@ contract Connected is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
         return "";
     }
 
-    function onRevert(RevertContext calldata context) external {
+    function onRevert(RevertContext calldata context) external onlyGateway {
         (uint256 tokenId, address sender, string memory uri) = abi.decode(
             context.revertMessage,
             (uint256, address, string)

--- a/examples/nft/contracts/Universal.sol
+++ b/examples/nft/contracts/Universal.sol
@@ -33,6 +33,11 @@ contract Universal is
 
     event CounterpartySet(address indexed zrc20, bytes indexed contractAddress);
 
+    modifier onlyGateway() {
+        require(msg.sender == address(gateway), "Caller is not the gateway");
+        _;
+    }
+
     constructor(
         address payable gatewayAddress,
         address initialOwner
@@ -102,7 +107,7 @@ contract Universal is
         address zrc20,
         uint256 amount,
         bytes calldata message
-    ) external override {
+    ) external override onlyGateway {
         if (keccak256(context.origin) != keccak256(counterparty[zrc20]))
             revert("Unauthorized");
 
@@ -140,7 +145,7 @@ contract Universal is
         }
     }
 
-    function onRevert(RevertContext calldata context) external {
+    function onRevert(RevertContext calldata context) external onlyGateway {
         (uint256 tokenId, address sender, string memory uri) = abi.decode(
             context.revertMessage,
             (uint256, address, string)

--- a/examples/nft/scripts/test.sh
+++ b/examples/nft/scripts/test.sh
@@ -45,31 +45,31 @@ npx hardhat connected-set-counterparty --network localhost --contract "$CONTRACT
 npx hardhat universal-set-counterparty --network localhost --contract "$CONTRACT_ZETACHAIN" --counterparty "$CONTRACT_ETHEREUM" --zrc20 "$ZRC20_ETHEREUM" --json &>/dev/null
 npx hardhat universal-set-counterparty --network localhost --contract "$CONTRACT_ZETACHAIN" --counterparty "$CONTRACT_BNB" --zrc20 "$ZRC20_BNB" --json &>/dev/null
 
-nft_balance
 npx hardhat localnet-check
+nft_balance
 
 NFT_ID=$(npx hardhat mint --network localhost --json --contract "$CONTRACT_ZETACHAIN" --token-uri https://example.com/nft/metadata/1 | jq -r '.tokenId')
 echo -e "\nMinted NFT with ID: $NFT_ID on ZetaChain."
 
-nft_balance
 npx hardhat localnet-check
+nft_balance
 
 echo -e "\nTransferring NFT: ZetaChain → Ethereum..."
 npx hardhat transfer --network localhost --json --token-id "$NFT_ID" --from "$CONTRACT_ZETACHAIN" --to "$ZRC20_ETHEREUM" 
 
-nft_balance
 npx hardhat localnet-check
+nft_balance
 
 echo -e "\nTransferring NFT: Ethereum → BNB..."
 npx hardhat transfer --network localhost --json --token-id "$NFT_ID" --from "$CONTRACT_ETHEREUM" --to "$ZRC20_BNB" --gas-amount 0.1
 
-nft_balance
 npx hardhat localnet-check
+nft_balance
 
 echo -e "\nTransferring NFT: BNB → ZetaChain..."
 npx hardhat transfer --network localhost --json --token-id "$NFT_ID" --from "$CONTRACT_BNB"
 
-nft_balance
 npx hardhat localnet-check
+nft_balance
 
 npx hardhat localnet-stop

--- a/examples/swap/contracts/Swap.sol
+++ b/examples/swap/contracts/Swap.sol
@@ -16,6 +16,11 @@ contract Swap is UniversalContract {
     GatewayZEVM public gateway;
     uint256 constant BITCOIN = 18332;
 
+    modifier onlyGateway() {
+        require(msg.sender == address(gateway), "Caller is not the gateway");
+        _;
+    }
+
     constructor(address systemContractAddress, address payable gatewayAddress) {
         systemContract = SystemContract(systemContractAddress);
         gateway = GatewayZEVM(gatewayAddress);
@@ -31,7 +36,7 @@ contract Swap is UniversalContract {
         address zrc20,
         uint256 amount,
         bytes calldata message
-    ) external override {
+    ) external override onlyGateway {
         Params memory params = Params({target: address(0), to: bytes("")});
         if (context.chainID == BITCOIN) {
             params.target = BytesHelperLib.bytesToAddress(message, 0);
@@ -105,5 +110,7 @@ contract Swap is UniversalContract {
         );
     }
 
-    function onRevert(RevertContext calldata revertContext) external override {}
+    function onRevert(
+        RevertContext calldata revertContext
+    ) external override onlyGateway {}
 }

--- a/examples/swap/contracts/SwapToAnyToken.sol
+++ b/examples/swap/contracts/SwapToAnyToken.sol
@@ -17,6 +17,11 @@ contract SwapToAnyToken is UniversalContract {
     GatewayZEVM public gateway;
     uint256 constant BITCOIN = 18332;
 
+    modifier onlyGateway() {
+        require(msg.sender == address(gateway), "Caller is not the gateway");
+        _;
+    }
+
     constructor(address systemContractAddress, address payable gatewayAddress) {
         systemContract = SystemContract(systemContractAddress);
         gateway = GatewayZEVM(gatewayAddress);
@@ -33,7 +38,7 @@ contract SwapToAnyToken is UniversalContract {
         address zrc20,
         uint256 amount,
         bytes calldata message
-    ) external virtual override {
+    ) external virtual override onlyGateway {
         Params memory params = Params({
             target: address(0),
             to: bytes(""),
@@ -147,5 +152,7 @@ contract SwapToAnyToken is UniversalContract {
         swapAndWithdraw(inputToken, amount, targetToken, recipient, withdraw);
     }
 
-    function onRevert(RevertContext calldata revertContext) external override {}
+    function onRevert(
+        RevertContext calldata revertContext
+    ) external override onlyGateway {}
 }


### PR DESCRIPTION
To prevent malicious third-party contract from calling `onCall` and `onRevert`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new access control modifier, `onlyGateway`, to enhance security across multiple contracts, ensuring that critical functions can only be executed by the designated gateway.
	- Updated various functions (`onCall`, `onRevert`) to include the `onlyGateway` modifier, reinforcing access restrictions.

- **Bug Fixes**
	- Improved error handling in the `Universal` contract to revert with a `TransferFailed` error if gas fee transfers fail.

- **Chores**
	- Modified the `test.sh` script to include calls to display NFT balances across different blockchain networks, enhancing visibility during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->