### PR TITLE
feat: add script to encode the withdrawAndCall payload for Sui

### DIFF
--- a/examples/call/sui/setup/encodeCallArgs.ts
+++ b/examples/call/sui/setup/encodeCallArgs.ts
@@ -1,6 +1,5 @@
 import { ethers } from "ethers";
 
-
 async function encode() {
   // this script abi encodes type arguments, objects and the message to be passed to the Sui connected contract
   // in protocol this encoded bytes array is passed to GatewayZEVM.withdrawAndCall
@@ -11,7 +10,7 @@ async function encode() {
 
   // accounts and data are abi encoded
   const encoded = ethers.utils.defaultAbiCoder.encode(
-    ["tuple(string[] typeArguments, byte32[] objects, bytes message)"],
+    ["tuple(string[] typeArguments, bytes32[] objects, bytes message)"],
     [[typeArguments, objects, message]]
   );
 

--- a/examples/call/sui/setup/encodeCallArgs.ts
+++ b/examples/call/sui/setup/encodeCallArgs.ts
@@ -26,5 +26,5 @@ async function encode() {
 }
 
 encode().catch((err) =>
-  console.error(`Encode args for sui examples error: ${err}, usage: encodeCall.ts <typeArguments> <objects> <message>`,)
+  console.error(`Encode args for sui examples error: ${err}, usage: encodeCall.ts <commaSeparatedTypeArguments> <commaSeparatedObjectIDs> <message>`,)
 );

--- a/examples/call/sui/setup/encodeCallArgs.ts
+++ b/examples/call/sui/setup/encodeCallArgs.ts
@@ -1,0 +1,23 @@
+import { ethers } from "ethers";
+
+
+async function encode() {
+  // this script abi encodes type arguments, objects and the message to be passed to the Sui connected contract
+  // in protocol this encoded bytes array is passed to GatewayZEVM.withdrawAndCall
+
+  const typeArguments: any[] = [];
+  const objects: any[] = [];
+  const message = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(""));
+
+  // accounts and data are abi encoded
+  const encoded = ethers.utils.defaultAbiCoder.encode(
+    ["tuple(string[] typeArguments, byte32[] objects, bytes message)"],
+    [[typeArguments, objects, message]]
+  );
+
+  console.log(encoded);
+}
+
+encode().catch((err) =>
+  console.error("Encode args for sui examples error:", err)
+);

--- a/examples/call/sui/setup/encodeCallArgs.ts
+++ b/examples/call/sui/setup/encodeCallArgs.ts
@@ -6,7 +6,7 @@ async function encode() {
 
   const args = process.argv.slice(2);
 
-  if (args.length < 3) {
+  if (args.length != 3) {
     throw new Error(`invalid argument number, expected 3, got ${args.length}`);
   }
 

--- a/examples/call/sui/setup/encodeCallArgs.ts
+++ b/examples/call/sui/setup/encodeCallArgs.ts
@@ -4,9 +4,17 @@ async function encode() {
   // this script abi encodes type arguments, objects and the message to be passed to the Sui connected contract
   // in protocol this encoded bytes array is passed to GatewayZEVM.withdrawAndCall
 
-  const typeArguments: any[] = [];
-  const objects: any[] = [];
-  const message = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(""));
+  const args = process.argv.slice(2);
+
+  if (args.length < 3) {
+    throw new Error(`invalid argument number, expected 3, got ${args.length}`);
+  }
+
+  const typeArguments: string[] = args[0].split(",").map((s) => s.trim());
+  const objects: string[] = args[1].split(",").map((s) =>
+    ethers.utils.hexZeroPad(s.trim(), 32)
+  );
+  const message = args[2];
 
   // accounts and data are abi encoded
   const encoded = ethers.utils.defaultAbiCoder.encode(
@@ -18,5 +26,5 @@ async function encode() {
 }
 
 encode().catch((err) =>
-  console.error("Encode args for sui examples error:", err)
+  console.error(`Encode args for sui examples error: ${err}, usage: encodeCall.ts <typeArguments> <objects> <message>`,)
 );

--- a/examples/call/sui/setup/encodeCallArgs.ts
+++ b/examples/call/sui/setup/encodeCallArgs.ts
@@ -16,7 +16,7 @@ async function encode() {
   );
   const message = args[2];
 
-  // accounts and data are abi encoded
+  // values are abi encoded
   const encoded = ethers.utils.defaultAbiCoder.encode(
     ["tuple(string[] typeArguments, bytes32[] objects, bytes message)"],
     [[typeArguments, objects, message]]


### PR DESCRIPTION
The script encode the payload following the current specification: `[list type arguments] [list shared object ids] [generic data bytes]`
Can find an example here how it can be used: https://github.com/lumtis/sui-zeta
```
export TOKEN_TYPE="0xb112f370bc8e3ba6e45ad1a954660099fc3e6de2a203df9d26e11aa0d870f635::token::TOKEN"
export CONFIG="0x57dd7b5841300199ac87b420ddeb48229523e76af423b4fce37da0cb78604408"
export POOL="0xbab1a2d90ea585eab574932e1b3467ff1d5d3f2aee55fed304f963ca2b9209eb"
export PARTNER="0xee6f1f44d24a8bf7268d82425d6e7bd8b9c48d11b2119b20756ee150c8e24ac3"
export CLOCK="0x039ce62b538a0d0fca21c3c3a5b99adf519d55e534c536568fbcca40ee61fb7e"
export MESSAGE="0x3573924024f4a7ff8e6755cb2d9fdeef69bdb65329f081d21b0b6ab37a265d06"

npx ts-node sui/setup/encodeCallArgs.ts \
  "$TOKEN_TYPE" \
  "$CONFIG,$POOL,$PARTNER,$CLOCK" \
  "$MESSAGE"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line tool that encodes input arguments for smart contract interactions. The tool processes lists of type identifiers, object references, and messages into a unified encoded format. It also validates the number of inputs, providing clear error feedback when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->