### PR TITLE
Remove unused IERC20 import

### DIFF
--- a/examples/swap/contracts/Swap.sol
+++ b/examples/swap/contracts/Swap.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.26;
 import {SystemContract, IZRC20} from "@zetachain/toolkit/contracts/SystemContract.sol";
 import {SwapHelperLib} from "@zetachain/toolkit/contracts/SwapHelperLib.sol";
 import {BytesHelperLib} from "@zetachain/toolkit/contracts/BytesHelperLib.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
 
 import {RevertContext, RevertOptions} from "@zetachain/protocol-contracts/contracts/Revert.sol";


### PR DESCRIPTION
The IERC20.sol import was not being used in the contract. This removes it to keep the code clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Cleaned up unused import statements to simplify the contract code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->