### PR TITLE
chore: update standard contracts to v2

### DIFF
--- a/examples/nft/.gitignore
+++ b/examples/nft/.gitignore
@@ -19,3 +19,5 @@ access_token
 localnet.json
 
 test-ledger
+
+.openzeppelin

--- a/examples/nft/package.json
+++ b/examples/nft/package.json
@@ -57,7 +57,7 @@
     "@solana/spl-memo": "^0.2.5",
     "@solana/web3.js": "^1.95.8",
     "@zetachain/protocol-contracts": "13.0.0",
-    "@zetachain/standard-contracts": "2.0.0-rc5",
+    "@zetachain/standard-contracts": "^2.0.0",
     "@zetachain/toolkit": "13.0.0-rc17",
     "validator": "^13.12.0",
     "zetachain": "^3.0.0"

--- a/examples/nft/package.json
+++ b/examples/nft/package.json
@@ -57,7 +57,7 @@
     "@solana/spl-memo": "^0.2.5",
     "@solana/web3.js": "^1.95.8",
     "@zetachain/protocol-contracts": "13.0.0",
-    "@zetachain/standard-contracts": "^2.0.0",
+    "@zetachain/standard-contracts": "2.0.1",
     "@zetachain/toolkit": "13.0.0-rc17",
     "validator": "^13.12.0",
     "zetachain": "^3.0.0"

--- a/examples/nft/yarn.lock
+++ b/examples/nft/yarn.lock
@@ -3285,10 +3285,10 @@
     "@zetachain/networks" "^10.0.0"
     ethers "5.6.8"
 
-"@zetachain/standard-contracts@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/@zetachain/standard-contracts/-/standard-contracts-2.0.0.tgz#118e86d420962e16226fa72ff9d15a1de6be7ce6"
-  integrity sha512-ozuFpprVqjP8LxGFpgfzsbhfFdwuX202KYWmYH76ppo9F+rCz0MAcpVWa8kpnvbMm8pckk8hakjhcl09CV6Mtw==
+"@zetachain/standard-contracts@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@zetachain/standard-contracts/-/standard-contracts-2.0.1.tgz#aefd28bb81f1f05b183bd73dc62bd68e456a6ebf"
+  integrity sha512-SHV9a1bSgy8litI/LRZ4VIus7Gsjy0wj3n9bZeIsEydn0C5NNZxYO4XW+P06dlEyDQjtcVJQHoQOyHkodBoVsQ==
 
 "@zetachain/toolkit@13.0.0-rc17":
   version "13.0.0-rc17"

--- a/examples/nft/yarn.lock
+++ b/examples/nft/yarn.lock
@@ -3285,10 +3285,10 @@
     "@zetachain/networks" "^10.0.0"
     ethers "5.6.8"
 
-"@zetachain/standard-contracts@2.0.0-rc5":
-  version "2.0.0-rc5"
-  resolved "https://registry.npmjs.org/@zetachain/standard-contracts/-/standard-contracts-2.0.0-rc5.tgz#448ebfcad73fa0dd9ebb0ae3da11bfdd1658f322"
-  integrity sha512-67EJz9fqF8XVrMpnahx55Jw8d8i3sdBG/Lq04kschXQ8HKCvbSBasoCVdAsi3LOELGTI4/uksAHJLb2D43g5jw==
+"@zetachain/standard-contracts@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@zetachain/standard-contracts/-/standard-contracts-2.0.0.tgz#118e86d420962e16226fa72ff9d15a1de6be7ce6"
+  integrity sha512-ozuFpprVqjP8LxGFpgfzsbhfFdwuX202KYWmYH76ppo9F+rCz0MAcpVWa8kpnvbMm8pckk8hakjhcl09CV6Mtw==
 
 "@zetachain/toolkit@13.0.0-rc17":
   version "13.0.0-rc17"

--- a/examples/token/.gitignore
+++ b/examples/token/.gitignore
@@ -19,3 +19,5 @@ access_token
 localnet.json
 
 test-ledger
+
+.openzeppelin

--- a/examples/token/package.json
+++ b/examples/token/package.json
@@ -57,7 +57,7 @@
     "@solana/spl-memo": "^0.2.5",
     "@solana/web3.js": "^1.95.8",
     "@zetachain/protocol-contracts": "13.0.0",
-    "@zetachain/standard-contracts": "^2.0.0",
+    "@zetachain/standard-contracts": "2.0.1",
     "@zetachain/toolkit": "13.0.0-rc17",
     "validator": "^13.12.0",
     "zetachain": "3.0.0"

--- a/examples/token/package.json
+++ b/examples/token/package.json
@@ -57,7 +57,7 @@
     "@solana/spl-memo": "^0.2.5",
     "@solana/web3.js": "^1.95.8",
     "@zetachain/protocol-contracts": "13.0.0",
-    "@zetachain/standard-contracts": "2.0.0-rc5",
+    "@zetachain/standard-contracts": "^2.0.0",
     "@zetachain/toolkit": "13.0.0-rc17",
     "validator": "^13.12.0",
     "zetachain": "3.0.0"

--- a/examples/token/yarn.lock
+++ b/examples/token/yarn.lock
@@ -3285,10 +3285,10 @@
     "@zetachain/networks" "^10.0.0"
     ethers "5.6.8"
 
-"@zetachain/standard-contracts@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/@zetachain/standard-contracts/-/standard-contracts-2.0.0.tgz#118e86d420962e16226fa72ff9d15a1de6be7ce6"
-  integrity sha512-ozuFpprVqjP8LxGFpgfzsbhfFdwuX202KYWmYH76ppo9F+rCz0MAcpVWa8kpnvbMm8pckk8hakjhcl09CV6Mtw==
+"@zetachain/standard-contracts@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/@zetachain/standard-contracts/-/standard-contracts-2.0.1.tgz#aefd28bb81f1f05b183bd73dc62bd68e456a6ebf"
+  integrity sha512-SHV9a1bSgy8litI/LRZ4VIus7Gsjy0wj3n9bZeIsEydn0C5NNZxYO4XW+P06dlEyDQjtcVJQHoQOyHkodBoVsQ==
 
 "@zetachain/toolkit@13.0.0-rc17":
   version "13.0.0-rc17"

--- a/examples/token/yarn.lock
+++ b/examples/token/yarn.lock
@@ -3285,10 +3285,10 @@
     "@zetachain/networks" "^10.0.0"
     ethers "5.6.8"
 
-"@zetachain/standard-contracts@2.0.0-rc5":
-  version "2.0.0-rc5"
-  resolved "https://registry.npmjs.org/@zetachain/standard-contracts/-/standard-contracts-2.0.0-rc5.tgz#448ebfcad73fa0dd9ebb0ae3da11bfdd1658f322"
-  integrity sha512-67EJz9fqF8XVrMpnahx55Jw8d8i3sdBG/Lq04kschXQ8HKCvbSBasoCVdAsi3LOELGTI4/uksAHJLb2D43g5jw==
+"@zetachain/standard-contracts@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@zetachain/standard-contracts/-/standard-contracts-2.0.0.tgz#118e86d420962e16226fa72ff9d15a1de6be7ce6"
+  integrity sha512-ozuFpprVqjP8LxGFpgfzsbhfFdwuX202KYWmYH76ppo9F+rCz0MAcpVWa8kpnvbMm8pckk8hakjhcl09CV6Mtw==
 
 "@zetachain/toolkit@13.0.0-rc17":
   version "13.0.0-rc17"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the dependency version for "@zetachain/standard-contracts" in example projects to the stable 2.0.1 release.
  - Added `.openzeppelin` to the ignore list in example projects to prevent tracking of build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->