### PR TITLE
ci: send analytics to posthog

### DIFF
--- a/.github/workflows/analytics.yaml
+++ b/.github/workflows/analytics.yaml
@@ -103,7 +103,7 @@ jobs:
           # Build JSON with jq to ensure valid formatting and numeric count
           jq -n \
             --arg api_key "$POSTHOG_API_KEY" \
-            --arg event "universal_contracts_count" \
+            --arg event "Universal contract count" \
             --arg distinct_id "github_actions/${{ github.repository }}" \
             --argjson count "$COUNT" \
             '{api_key:$api_key, event:$event, distinct_id:$distinct_id, properties:{count:$count}}' \


### PR DESCRIPTION
Daily count universal contracts on GitHub and send data to Posthog.

<img width="721" height="524" alt="Screenshot 2025-09-01 at 18 22 07" src="https://github.com/user-attachments/assets/2e173c4e-f8fd-4f6d-8858-0ca5030dcce9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a daily scheduled workflow at 00:00 UTC; manual trigger remains available.
  * Runs a repository count via GitHub code search and exposes the numeric result to subsequent steps.
  * Sends the count to the analytics platform as an event; skips gracefully if credentials are missing and defaults to a sensible host when unspecified.
  * Improved workflow step naming and structure for clearer execution and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->